### PR TITLE
Ajueste - IContentReader

### DIFF
--- a/src/SmartText/Builder/ConfigurationBuilderExtensions.cs
+++ b/src/SmartText/Builder/ConfigurationBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SmartText.Implementation;
+using System;
 
 namespace SmartText.Builder
 {
@@ -18,7 +19,7 @@ namespace SmartText.Builder
 
             builder.FilePath = filePath;
 
-            return builder;
+            return UseFileReader(builder, () => new FileContentReader(filePath));
         }
 
         public static IConfigurationBuilder AutoLoadFile(this IConfigurationBuilder builder, bool autoLoad = false)
@@ -35,17 +36,33 @@ namespace SmartText.Builder
 
         public static IConfigurationBuilder UseFileReader(this IConfigurationBuilder builder, IContentReader reader)
         {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
             if (reader is null)
             {
                 throw new ArgumentNullException(nameof(reader));
             }
 
-            builder.ContentReader = reader;
+            return UseFileReader(builder, () => reader);
+        }
+
+        public static IConfigurationBuilder UseFileReader<T>(this IConfigurationBuilder builder, T reader)
+             where T : IContentReader
+        {
+            return UseFileReader(builder, () => reader);
+        }
+
+        public static IConfigurationBuilder UseFileReader(this IConfigurationBuilder builder, Func<IContentReader> readerFactory)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (readerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(readerFactory));
+            }
+
+            builder.ContentReaderFactory = readerFactory;
 
             return builder;
         }

--- a/src/SmartText/Builder/IConfigurationBuilder.cs
+++ b/src/SmartText/Builder/IConfigurationBuilder.cs
@@ -11,6 +11,6 @@ namespace SmartText.Builder
 
         bool AutoLoadFile { get; set; }
 
-        IContentReader ContentReader { get; set; }
+        Func<IContentReader> ContentReaderFactory { get; set; }
     }
 }

--- a/src/SmartText/IContentReader.cs
+++ b/src/SmartText/IContentReader.cs
@@ -4,8 +4,8 @@ namespace SmartText
 {
     public interface IContentReader
     {
-        string[] ReadAllLines(string filePath);
+        string[] ReadAllLines();
 
-        Task<string[]> ReadAllLinesAsync(string filePath);
+        Task<string[]> ReadAllLinesAsync();
     }
 }

--- a/src/SmartText/Implementation/FileContentReader.cs
+++ b/src/SmartText/Implementation/FileContentReader.cs
@@ -5,11 +5,15 @@ namespace SmartText.Implementation
 {
     internal class FileContentReader : IContentReader
     {
-        public string[] ReadAllLines(string filePath) => File.ReadAllLines(filePath);
+        private readonly string _filePath;
 
-        public Task<string[]> ReadAllLinesAsync(string filePath)
+        public FileContentReader(string filePath)
         {
-            return Task.FromResult(File.ReadAllLines(filePath));
+            _filePath = filePath ?? throw new System.ArgumentNullException(nameof(filePath));
         }
+
+        public string[] ReadAllLines() => File.ReadAllLines(_filePath);
+
+        public Task<string[]> ReadAllLinesAsync() => Task.FromResult(File.ReadAllLines(_filePath));
     }
 }

--- a/src/SmartText/Implementation/SectionReader.cs
+++ b/src/SmartText/Implementation/SectionReader.cs
@@ -49,7 +49,7 @@ namespace SmartText.Implementation
 
                 return true;
             }
-            catch (Exception ex) // TODO: Remover the exception variable
+            catch
             {
                 result = default;
                 return false;

--- a/src/SmartText/Model/Configuration.cs
+++ b/src/SmartText/Model/Configuration.cs
@@ -10,7 +10,6 @@ namespace SmartText
             Sections = new List<Section>();
             FilePath = string.Empty;
             AutoLoadFile = false;
-            ContentReader = new FileContentReader();
         }
 
         public IEnumerable<Section> Sections { get; set; }

--- a/src/SmartText/SmartText.cs
+++ b/src/SmartText/SmartText.cs
@@ -31,12 +31,12 @@ namespace SmartText
 
         public void LoadContent()
         {
-            _data = _contentReader.ReadAllLines(Configuration.FilePath);
+            _data = _contentReader.ReadAllLines();
         }
 
         public async Task LoadContentAsync()
         {
-            _data = await _contentReader.ReadAllLinesAsync(Configuration.FilePath);
+            _data = await _contentReader.ReadAllLinesAsync();
         }
 
         public ISectionReader<TSection> Reader<TSection>() where TSection : class, new()


### PR DESCRIPTION
Ajustes no uso do `IContentReader`

- Remoção do parâmetro `filePath`, fazendo com que as implementações da interface não precisem depender do parâmetro, tornando livre a forma de leitura do arquivo;
- Migração do uso do `filePath` para o ContentBuilder, mantendo a implementação padrão, de leitura de um arquivo à partir de um caminho;
- Adição de um `readerFactory`, que permite a construção de um IContentReader customizável, que será chamado no momento do build do objeto `Configuration`.